### PR TITLE
TC_06.002.03 | Error when renaming a project with an empty name

### DIFF
--- a/tests/sk-rename.spec.ts
+++ b/tests/sk-rename.spec.ts
@@ -51,4 +51,16 @@ test.describe("US_06.002 | Multibranch pipeline Configuration > Rename", () => {
 
         await expect(updatedProjectName).toHaveText(`New ${jenkinsData.projectName}`);
     });
+
+    test("TC_06.002.03 | Error when renaming a project with an empty name", async ({ page }: { page: Page }) => {
+        await page.getByRole("button", {name: "Save"}).click();
+        await page.getByRole("link", {name: "Rename"}).click();
+
+        await page.locator("[name='newName']").clear();
+        await page.getByRole("button", {name: "Rename"}).click();
+        await page.waitForURL("**/confirmRename");
+
+        await expect(page.getByRole("heading")).toHaveText(jenkinsData.errorHeading);
+        await expect(page.locator("h1+p")).toHaveText(jenkinsData.errorMessages.emptyProjectName);
+    });
 });

--- a/tests/testData/sk-data.ts
+++ b/tests/testData/sk-data.ts
@@ -1,3 +1,7 @@
 export const jenkinsData = {
-	projectName: Math.floor(Math.random() * 10000) + "projectName"
+	projectName: Math.floor(Math.random() * 10000) + "projectName",
+	errorHeading: "Error",
+	errorMessages: {
+		emptyProjectName: "No name is specified"
+	}
 };


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/169