### PR TITLE
TC_01.001.21 | Verify new item page opens from dashboard

### DIFF
--- a/tests/tests/tl-createNewItem.spec.ts
+++ b/tests/tests/tl-createNewItem.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect, Page } from "@/base";
+
+test.describe("US_01.001 | New Item > Create a new item", () => {
+  test("TC_01.001.21 | Verify new item page opens from dashboard", async ({ page }: { page: Page }) => {
+    // Locators
+    const newItemLink = page.getByRole("link", { name: "New Item" });
+    const itemNameInput = page.locator("#name");
+    const okButton = page.locator("#ok-button");
+
+    // Steps
+    await newItemLink.click();
+
+    // Expected results
+    await expect(page).toHaveURL(/newJob/);
+    await expect(itemNameInput).toBeVisible();
+    await expect(okButton).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Test Case

TC_01.001.21 | New Item > Create a new item > Verify new item page opens from dashboard
### What was done
- Added Playwright test for opening the New Item creation page from Jenkins dashboard
- Verified URL contains newJob
- Verified item name input is visible
- Verified OK button is visible

### Test result
- Passed locally using:
npx playwright test --ui

### Related card
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/180