### PR TITLE
Tc 01.001.22 blank item name validation

### DIFF
--- a/tests/tests/tl-createNewItem.spec.ts
+++ b/tests/tests/tl-createNewItem.spec.ts
@@ -15,4 +15,21 @@ test.describe("US_01.001 | New Item > Create a new item", () => {
     await expect(itemNameInput).toBeVisible();
     await expect(okButton).toBeVisible();
   });
+  
+  test("TC_01.001.22 | Verify blank item name validation", async ({ page }: { page: Page }) => {
+  // Locators
+  const newItemLink = page.getByRole("link", { name: "New Item" });
+  const freestyleProject = page.locator("#j-add-item-type-standalone-projects li[class*=FreeStyleProject]");
+  const okButton = page.locator("#ok-button");
+
+  // Steps
+  await newItemLink.click();
+
+  // Leave item name field blank
+  await freestyleProject.click();
+
+  // Expected result
+  await expect(okButton).toBeDisabled();
+  });
+
 });


### PR DESCRIPTION
### Test Case
TC_01.001.22 | New Item > Create a new item > Verify blank item name validation

### What was done
- Added Playwright test for blank item name validation
- Verified that OK button remains disabled when item name is empty

### Test result
- Passed locally using:
npx playwright test --ui

### Related card
https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182560751&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C181