### PR TITLE
Refactor: extract locators and helpers for New Item tests

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -1,3 +1,17 @@
-export const invalidItemData = {
-  invalidName: "test?item"
+import { Page } from "@/base";
+
+export const newItemData = {
+  invalidItemName: "test?item",
 };
+
+export const newItemLocators = {
+  newItemLink: "a[href='/view/all/newJob']",
+  itemNameInput: "#name",
+  freestyleProject: "#j-add-item-type-standalone-projects li[class*=FreeStyleProject]",
+  okButton: "#ok-button",
+  invalidNameMessage: "#itemname-invalid",
+};
+
+export async function openNewItemPage(page: Page): Promise<void> {
+  await page.locator(newItemLocators.newItemLink).click();
+}

--- a/tests/tl-createNewItem.spec.ts
+++ b/tests/tl-createNewItem.spec.ts
@@ -1,58 +1,27 @@
 import { test, expect, Page } from "@/base";
-import { invalidItemData } from "./testData/tl-data";
+import { newItemData, newItemLocators, openNewItemPage } from "./testData/tl-data";
 
 test.describe("US_01.001 | New Item > Create a new item", () => {
   test("TC_01.001.21 | Verify new item page opens from dashboard", async ({ page }: { page: Page }) => {
-    // Locators
-    const newItemLink = page.getByRole("link", { name: "New Item" });
-    const itemNameInput = page.locator("#name");
-    const okButton = page.locator("#ok-button");
+    await openNewItemPage(page);
 
-    // Steps
-    await newItemLink.click();
-
-    // Expected results
     await expect(page).toHaveURL(/newJob/);
-    await expect(itemNameInput).toBeVisible();
-    await expect(okButton).toBeVisible();
   });
-  
+
   test("TC_01.001.22 | Verify blank item name validation", async ({ page }: { page: Page }) => {
-  // Locators
-  const newItemLink = page.getByRole("link", { name: "New Item" });
-  const freestyleProject = page.locator("#j-add-item-type-standalone-projects li[class*=FreeStyleProject]");
-  const okButton = page.locator("#ok-button");
+    await openNewItemPage(page);
 
-  // Steps
-  await newItemLink.click();
+    await page.locator(newItemLocators.freestyleProject).click();
 
-  // Leave item name field blank
-  await freestyleProject.click();
-
-  // Expected result
-  await expect(okButton).toBeDisabled();
+    await expect(page.locator(newItemLocators.okButton)).toBeDisabled();
   });
 
-  test("TC_01.001.23 | Verify unsupported special characters validation", async ({ page }) => {
-  // Locators
-  const newItemLink = page.getByRole("link", { name: "New Item" });
-  const itemNameInput = page.locator("#name");
-  const freestyleProject = page.locator("#j-add-item-type-standalone-projects li[class*=FreeStyleProject]");
-  const okButton = page.locator("#ok-button");
-  const invalidNameMessage = page.locator("#itemname-invalid");
+  test("TC_01.001.23 | Verify unsupported special characters validation", async ({ page }: { page: Page }) => {
+    await openNewItemPage(page);
 
-  // 1. Open New Item page
-  await newItemLink.click();
+    await page.locator(newItemLocators.itemNameInput).fill(newItemData.invalidItemName);
+    await page.locator(newItemLocators.freestyleProject).click();
 
-  // 2. Enter item name with unsupported special character
-  await itemNameInput.fill("test?item");
-
-  // 3. Select "Freestyle project"
-  await freestyleProject.click();
-
-  // 4. Verify warning message is displayed
-  await expect(invalidNameMessage).toBeVisible();
-  await expect(invalidNameMessage).toContainText("unsafe character");
-});
-
+    await expect(page.locator(newItemLocators.invalidNameMessage)).toBeVisible();
+    await expect(page.locator(newItemLocators.invalidNameMessage)).toContainText("unsafe character");  });
 });


### PR DESCRIPTION
### What was done
- Extracted locators and test data into tl-data.ts
- Added helper function to open New Item page
- Refactored New Item tests to use shared data and locators

### Why
- Improve readability and maintainability
- Reduce duplication across tests

### Test result
- All tests passed locally using:
npx playwright test --ui