### PR TITLE
TC_05.001.03 | Folder Configuration > Verify Configure page opens

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -12,6 +12,23 @@ export const newItemLocators = {
   invalidNameMessage: "#itemname-invalid",
 };
 
+export const folderConfigData = {
+  folderName: "test-folder-config",
+};
+
+export const folderConfigLocators = {
+  folderType: ".com_cloudbees_hudson_plugins_folder_Folder",
+  configureLink: "a[href$='/configure']",
+};
+
 export async function openNewItemPage(page: Page): Promise<void> {
   await page.locator(newItemLocators.newItemLink).click();
+}
+
+export async function createFolder(page: Page, folderName: string): Promise<void> {
+  await openNewItemPage(page);
+  await page.locator(newItemLocators.itemNameInput).fill(folderName);
+  await page.locator(folderConfigLocators.folderType).click();
+  await page.locator(newItemLocators.okButton).click();
+  await page.locator("button[name='Submit']").click();
 }

--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect, Page } from "@/base";
+import { createFolder, folderConfigData, folderConfigLocators } from "./testData/tl-data";
+
+test.describe("US_05.001 | Folder Configuration > Display Name and Description", () => {
+  test("TC_05.001.03 | Verify Configure page opens", async ({ page }: { page: Page }) => {
+    await createFolder(page, folderConfigData.folderName);
+
+    await page.locator(folderConfigLocators.configureLink).click();
+
+    await expect(page).toHaveURL(/configure/);
+  });
+});


### PR DESCRIPTION
### Test Case
TC_05.001.03 | Folder Configuration > Verify Configure page opens

### What was done
- Added Playwright test to verify Configure page opens for Folder
- Reused helper createFolder from tl-data

### Test result
- Passed locally using:
npx playwright test --ui

### Related card
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/248