### PR TITLE
TC_05.001.04 | Folder Configuration > Display Name and Description > Verify Display Name and Description fields are available

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -17,7 +17,7 @@ export const folderConfigData = {
 };
 
 export const folderConfigLocators = {
-  folderType: ".com_cloudbees_hudson_plugins_folder_Folder",
+  folderType: "li.com_cloudbees_hudson_plugins_folder_Folder",
   configureLink: "a[href$='/configure']",
 };
 
@@ -30,5 +30,6 @@ export async function createFolder(page: Page, folderName: string): Promise<void
   await page.locator(newItemLocators.itemNameInput).fill(folderName);
   await page.locator(folderConfigLocators.folderType).click();
   await page.locator(newItemLocators.okButton).click();
+  await page.locator("button[name='Submit']").waitFor();
   await page.locator("button[name='Submit']").click();
 }

--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, Page } from "@/base";
 import { createFolder, folderConfigData, folderConfigLocators } from "./testData/tl-data";
 
 test.describe("US_05.001 | Folder Configuration > Display Name and Description", () => {
+
   test("TC_05.001.03 | Verify Configure page opens", async ({ page }: { page: Page }) => {
     await createFolder(page, folderConfigData.folderName);
 
@@ -9,4 +10,14 @@ test.describe("US_05.001 | Folder Configuration > Display Name and Description",
 
     await expect(page).toHaveURL(/configure/);
   });
+
+  test("TC_05.001.04 | Verify Display Name and Description fields are available", async ({ page }: { page: Page }) => {
+  await createFolder(page, folderConfigData.folderName);
+
+  await page.locator(folderConfigLocators.configureLink).click();
+
+  await expect(page.getByLabel("Display Name")).toBeVisible();
+  await expect(page.getByText("Description")).toBeVisible();
+});
+
 });


### PR DESCRIPTION
### Test Case

TC_05.001.04 | Folder Configuration > Display Name and Description > Verify Display Name and Description fields are available

### What was done

- Added Playwright test to verify Description field is available on Folder configuration page

- Reused createFolder helper from tl-data

### Test result

- Passed locally using:

npx playwright test --ui

### Related card

https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182885323&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C229