### PR TITLE
TC_05.001.05 | Folder Configuration > Display Name and Description > Verify user can update Display Name

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -14,6 +14,7 @@ export const newItemLocators = {
 
 export const folderConfigData = {
   folderName: "test-folder-config",
+  displayName: "Updated Folder Display Name",
 };
 
 export const folderConfigLocators = {

--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -20,4 +20,18 @@ test.describe("US_05.001 | Folder Configuration > Display Name and Description",
   await expect(page.getByText("Description")).toBeVisible();
 });
 
+  test("TC_05.001.05 | Verify user can update Display Name", async ({ page }: { page: Page }) => {
+  await createFolder(page, folderConfigData.folderName);
+
+  await page.locator(folderConfigLocators.configureLink).click();
+
+  await page.getByText("Display Name").locator("..").locator("input").fill(folderConfigData.displayName);
+
+  await page.locator("button[name='Submit']").click();
+
+  await expect(
+  page.getByRole("heading", { name: folderConfigData.displayName })
+).toBeVisible();
+});
+
 });


### PR DESCRIPTION
### Test Case
TC_05.001.05 | Folder Configuration > Display Name and Description > Verify user can update Display Name

### What was done
- Added Playwright test to verify updating Display Name for Folder
- Reused createFolder helper
- Verified updated Display Name is displayed on overview page

### Test result
- Passed locally using:
npx playwright test --ui

### Related card
https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182885449&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C230