### PR TITLE
TC_02.002.06 | Freestyle Project Configuration > Project Description > Verify Description field is displayed

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -2,6 +2,7 @@ import { Page } from "@/base";
 
 export const newItemData = {
   invalidItemName: "test?item",
+  freestyleProjectName: "test-freestyle-project",
 };
 
 export const newItemLocators = {
@@ -31,5 +32,13 @@ export async function createFolder(page: Page, folderName: string): Promise<void
   await page.locator(folderConfigLocators.folderType).click();
   await page.locator(newItemLocators.okButton).click();
   await page.locator("button[name='Submit']").waitFor();
+  await page.locator("button[name='Submit']").click();
+}
+
+export async function createFreestyleProject(page: Page, projectName: string): Promise<void> {
+  await openNewItemPage(page);
+  await page.locator(newItemLocators.itemNameInput).fill(projectName);
+  await page.locator(newItemLocators.freestyleProject).click();
+  await page.locator(newItemLocators.okButton).click();
   await page.locator("button[name='Submit']").click();
 }

--- a/tests/tl-freestyleConfiguration.spec.ts
+++ b/tests/tl-freestyleConfiguration.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect, Page } from "@/base";
+import { createFreestyleProject, newItemData } from "./testData/tl-data";
+
+test.describe("US_02.002 | Freestyle Project Configuration > Project Description", () => {
+
+  test("TC_02.002.06 | Verify Description field is displayed", async ({ page }: { page: Page }) => {
+    await createFreestyleProject(page, newItemData.freestyleProjectName);
+
+    await page.locator("a[href$='/configure']").click();
+
+    await expect(page.getByText("Description")).toBeVisible();
+  });
+
+});


### PR DESCRIPTION
### Test Case
TC_02.002.06 | Freestyle Project Configuration > Project Description > Verify Description field is displayed

### What was done
- Added Playwright test to verify Description field is visible in Freestyle project configuration
- Reused createFreestyleProject helper

### Test result
- Passed locally using:
npx playwright test --ui

### Related card
https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182891226&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C239