### PR TITLE
TC_01.001.25 | New Item > Create a new item > Verify warning for duplicate item name

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -3,6 +3,7 @@ import { Page } from "@/base";
 export const newItemData = {
   invalidItemName: "test?item",
   freestyleProjectName: "test-freestyle-project",
+  existingItemName: "existing-item",
 };
 
 export const newItemLocators = {
@@ -24,6 +25,7 @@ export const folderConfigLocators = {
 };
 
 export async function openNewItemPage(page: Page): Promise<void> {
+  await page.goto("/");
   await page.locator(newItemLocators.newItemLink).click();
 }
 

--- a/tests/tl-createNewItem.spec.ts
+++ b/tests/tl-createNewItem.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@/base";
-import { newItemData, newItemLocators, openNewItemPage } from "./testData/tl-data";
+import { newItemData, newItemLocators, openNewItemPage, createFreestyleProject } from "./testData/tl-data";
 
 test.describe("US_01.001 | New Item > Create a new item", () => {
   test("TC_01.001.21 | Verify new item page opens from dashboard", async ({ page }: { page: Page }) => {
@@ -33,7 +33,17 @@ test.describe("US_01.001 | New Item > Create a new item", () => {
   await page.locator(newItemLocators.freestyleProject).click();
   await page.locator(newItemLocators.okButton).click();
 
-  await expect(page.getByText(newItemData.freestyleProjectName)).toBeVisible();
+  await expect(page.getByRole("link", { name: newItemData.freestyleProjectName })).toBeVisible();});
+
+  test("TC_01.001.25 | Verify warning for duplicate item name", async ({ page }: { page: Page }) => {
+  await createFreestyleProject(page, newItemData.existingItemName);
+
+  await openNewItemPage(page);
+
+  await page.locator(newItemLocators.itemNameInput).fill(newItemData.existingItemName);
+  await page.locator(newItemLocators.freestyleProject).click();
+
+  await expect(page.getByText(`A job already exists with the name ‘${newItemData.existingItemName}’`)).toBeVisible();
 });
 
 });


### PR DESCRIPTION
### Test Case
TC_01.001.25 | New Item > Create a new item > Verify warning for duplicate item name

### What was done
- Added Playwright test to verify that user cannot create a new item with a duplicate name
- Validated that warning message is displayed when entering an existing item name
- Verified that item type selection does not allow creation with duplicate name
- Improved locator strategy to avoid strict mode issues

### Test result
- Passed locally using:
npx playwright test --ui

### Notes
- Improved test stability by updating the helper to always open the New Item page from the Dashboard
- Replaced a flaky text-based locator with a more stable role-based selector in a related test

### Related card
https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182564478&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C184