### PR TITLE
TC_05.001.06 | Folder Configuration > Display Name and Description > Verify user can update Description

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -1,5 +1,9 @@
 import { Page } from "@/base";
 
+export const commonLocators = {
+  submitButton: "button[name='Submit']",
+};
+
 export const newItemData = {
   invalidItemName: "test?item",
   freestyleProjectName: "test-freestyle-project",
@@ -16,11 +20,13 @@ export const newItemLocators = {
 export const folderConfigData = {
   folderName: "test-folder-config",
   displayName: "Updated Folder Display Name",
+  updatedDescription: "Updated folder description.",
 };
 
 export const folderConfigLocators = {
   folderType: "li.com_cloudbees_hudson_plugins_folder_Folder",
   configureLink: "a[href$='/configure']",
+  descriptionTextarea: "textarea",
 };
 
 export async function openNewItemPage(page: Page): Promise<void> {

--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -47,7 +47,7 @@ test.describe("US_05.001 | Folder Configuration > Display Name and Description",
 
   await page.locator(commonLocators.submitButton).click();
 
-  await expect(page.getByText(folderConfigData.updatedDescription, { exact: true })).toBeVisible();
+  await expect(page.locator("#main-panel").getByText(folderConfigData.updatedDescription, { exact: true })).toBeVisible();
 });
 
 });

--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -12,42 +12,40 @@ test.describe("US_05.001 | Folder Configuration > Display Name and Description",
   });
 
   test("TC_05.001.04 | Verify Display Name and Description fields are available", async ({ page }: { page: Page }) => {
-  await createFolder(page, folderConfigData.folderName);
+    await createFolder(page, folderConfigData.folderName);
 
-  await page.locator(folderConfigLocators.configureLink).click();
+    await page.locator(folderConfigLocators.configureLink).click();
 
-  await expect(page.getByLabel("Display Name")).toBeVisible();
-  await expect(page.getByText("Description")).toBeVisible();
+    await expect(page.getByLabel("Display Name")).toBeVisible();
+    await expect(page.getByText("Description")).toBeVisible();
 });
 
   test("TC_05.001.05 | Verify user can update Display Name", async ({ page }: { page: Page }) => {
-  await createFolder(page, folderConfigData.folderName);
+    await createFolder(page, folderConfigData.folderName);
 
-  await page.locator(folderConfigLocators.configureLink).click();
+    await page.locator(folderConfigLocators.configureLink).click();
 
-  await page.getByText("Display Name").locator("..").locator("input").fill(folderConfigData.displayName);
+    await page.getByText("Display Name").locator("..").locator("input").fill(folderConfigData.displayName);
 
-  await page.locator(commonLocators.submitButton).click();
+    await page.locator(commonLocators.submitButton).click();
 
-  await expect(
-  page.getByRole("heading", { name: folderConfigData.displayName })
-).toBeVisible();
-});
+    await expect(page.getByRole("heading", { name: folderConfigData.displayName })).toBeVisible();
+  });
 
   test("TC_05.001.06 | Verify user can update Description", async ({ page }: { page: Page }) => {
-  await createFolder(page, folderConfigData.folderName);
+    await createFolder(page, folderConfigData.folderName);
 
-  await page.goto(`/job/${folderConfigData.folderName}/configure`);
+    await page.goto(`/job/${folderConfigData.folderName}/configure`);
 
-  const descriptionTextarea = page.locator(folderConfigLocators.descriptionTextarea);
+    const descriptionTextarea = page.locator(folderConfigLocators.descriptionTextarea);
 
-  await descriptionTextarea.clear();
-  await descriptionTextarea.fill(folderConfigData.updatedDescription);
-  await descriptionTextarea.press("Tab");
+    await descriptionTextarea.clear();
+    await descriptionTextarea.fill(folderConfigData.updatedDescription);
+    await descriptionTextarea.press("Tab");
 
-  await page.locator(commonLocators.submitButton).click();
+    await page.locator(commonLocators.submitButton).click();
 
-  await expect(page.locator("#main-panel").getByText(folderConfigData.updatedDescription, { exact: true })).toBeVisible();
-});
+    await expect(page.locator("#main-panel").getByText(folderConfigData.updatedDescription, { exact: true })).toBeVisible();
+  });
 
 });

--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@/base";
-import { createFolder, folderConfigData, folderConfigLocators } from "./testData/tl-data";
+import { commonLocators, createFolder, folderConfigData, folderConfigLocators } from "./testData/tl-data";
 
 test.describe("US_05.001 | Folder Configuration > Display Name and Description", () => {
 
@@ -27,11 +27,27 @@ test.describe("US_05.001 | Folder Configuration > Display Name and Description",
 
   await page.getByText("Display Name").locator("..").locator("input").fill(folderConfigData.displayName);
 
-  await page.locator("button[name='Submit']").click();
+  await page.locator(commonLocators.submitButton).click();
 
   await expect(
   page.getByRole("heading", { name: folderConfigData.displayName })
 ).toBeVisible();
+});
+
+  test("TC_05.001.06 | Verify user can update Description", async ({ page }: { page: Page }) => {
+  await createFolder(page, folderConfigData.folderName);
+
+  await page.goto(`/job/${folderConfigData.folderName}/configure`);
+
+  const descriptionTextarea = page.locator(folderConfigLocators.descriptionTextarea);
+
+  await descriptionTextarea.clear();
+  await descriptionTextarea.fill(folderConfigData.updatedDescription);
+  await descriptionTextarea.press("Tab");
+
+  await page.locator(commonLocators.submitButton).click();
+
+  await expect(page.getByText(folderConfigData.updatedDescription, { exact: true })).toBeVisible();
 });
 
 });


### PR DESCRIPTION
### Test Case
TC_05.001.06 | Folder Configuration > Display Name and Description > Verify user can update Description

### What was done
- Added Playwright test to verify that user can update Folder Description

### Test result
- Passed locally using:
npx playwright test --ui

Closes #231

https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182885580&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C231
