### PR TITLE
TC_02.002.08 | Freestyle Project Configuration > Project Description > Verify description is displayed after Save

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -24,6 +24,10 @@ export const folderConfigLocators = {
   configureLink: "a[href$='/configure']",
 };
 
+export const freestyleConfigData = {
+  description: "This project is used for automated CI/CD workflow testing.",
+};
+
 export async function openNewItemPage(page: Page): Promise<void> {
   await page.goto("/");
   await page.locator(newItemLocators.newItemLink).click();

--- a/tests/tl-createNewItem.spec.ts
+++ b/tests/tl-createNewItem.spec.ts
@@ -27,24 +27,25 @@ test.describe("US_01.001 | New Item > Create a new item", () => {
   });
 
   test("TC_01.001.24 | Verify successful item creation", async ({ page }: { page: Page }) => {
-  await openNewItemPage(page);
+    await openNewItemPage(page);
 
-  await page.locator(newItemLocators.itemNameInput).fill(newItemData.freestyleProjectName);
-  await page.locator(newItemLocators.freestyleProject).click();
-  await page.locator(newItemLocators.okButton).click();
+    await page.locator(newItemLocators.itemNameInput).fill(newItemData.freestyleProjectName);
+    await page.locator(newItemLocators.freestyleProject).click();
+    await page.locator(newItemLocators.okButton).click();
 
-  await expect(page.getByRole("link", { name: newItemData.freestyleProjectName })).toBeVisible();});
+    await expect(page.getByRole("link", { name: newItemData.freestyleProjectName })).toBeVisible();
+  });
 
   test("TC_01.001.25 | Verify warning for duplicate item name", async ({ page }: { page: Page }) => {
-  await createFreestyleProject(page, newItemData.existingItemName);
+    await createFreestyleProject(page, newItemData.existingItemName);
 
-  await openNewItemPage(page);
+    await openNewItemPage(page);
 
-  await page.locator(newItemLocators.itemNameInput).fill(newItemData.existingItemName);
-  await page.locator(newItemLocators.freestyleProject).click();
+    await page.locator(newItemLocators.itemNameInput).fill(newItemData.existingItemName);
+    await page.locator(newItemLocators.freestyleProject).click();
 
-  await expect(page.getByText(`A job already exists with the name ‘${newItemData.existingItemName}’`)).toBeVisible();
-});
+    await expect(page.getByText(`A job already exists with the name ‘${newItemData.existingItemName}’`)).toBeVisible();
+  });
 
 });
 

--- a/tests/tl-freestyleConfiguration.spec.ts
+++ b/tests/tl-freestyleConfiguration.spec.ts
@@ -19,4 +19,19 @@ test.describe("US_02.002 | Freestyle Project Configuration > Project Description
   await expect(page.getByRole("link", { name: "Preview" })).toBeVisible();
 });
 
+  test("TC_02.002.08 | Verify description is displayed after Save", async ({ page }: { page: Page }) => {
+
+  const description = "This project is used for automated CI/CD workflow testing.";
+  await createFreestyleProject(page, newItemData.freestyleProjectName);
+  await page.goto(`/job/${newItemData.freestyleProjectName}/configure`);
+
+  const descriptionTextarea = page.locator('textarea[name="description"]');  await descriptionTextarea.clear();
+  await descriptionTextarea.fill(description);
+  await descriptionTextarea.press("Tab");
+  await page.locator("button[name='Submit']").click();
+
+  await expect(page.locator("#main-panel").getByText(description, { exact: true })).toBeVisible();
+
+});
+
 });

--- a/tests/tl-freestyleConfiguration.spec.ts
+++ b/tests/tl-freestyleConfiguration.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@/base";
-import { createFreestyleProject, newItemData } from "./testData/tl-data";
+import { createFreestyleProject, newItemData, freestyleConfigData } from "./testData/tl-data";
 
 test.describe("US_02.002 | Freestyle Project Configuration > Project Description", () => {
 
@@ -12,26 +12,26 @@ test.describe("US_02.002 | Freestyle Project Configuration > Project Description
   });
 
   test("TC_02.002.07 | Verify Preview option is available", async ({ page }: { page: Page }) => {
-  await createFreestyleProject(page, newItemData.freestyleProjectName);
+    await createFreestyleProject(page, newItemData.freestyleProjectName);
 
-  await page.locator("a[href$='/configure']").click();
+    await page.locator("a[href$='/configure']").click();
 
-  await expect(page.getByRole("link", { name: "Preview" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Preview" })).toBeVisible();
 });
 
   test("TC_02.002.08 | Verify description is displayed after Save", async ({ page }: { page: Page }) => {
+    await createFreestyleProject(page, newItemData.freestyleProjectName);
 
-  const description = "This project is used for automated CI/CD workflow testing.";
-  await createFreestyleProject(page, newItemData.freestyleProjectName);
-  await page.goto(`/job/${newItemData.freestyleProjectName}/configure`);
+    await page.goto(`/job/${newItemData.freestyleProjectName}/configure`);
 
-  const descriptionTextarea = page.locator('textarea[name="description"]');  await descriptionTextarea.clear();
-  await descriptionTextarea.fill(description);
-  await descriptionTextarea.press("Tab");
-  await page.locator("button[name='Submit']").click();
+    const descriptionTextarea = page.locator('textarea[name="description"]');
 
-  await expect(page.locator("#main-panel").getByText(description, { exact: true })).toBeVisible();
+    await descriptionTextarea.clear();
+    await descriptionTextarea.fill(freestyleConfigData.description);
 
-});
+    await page.locator("button[name='Submit']").click();
+
+    await expect(page.locator("#main-panel").getByText(freestyleConfigData.description, { exact: true })).toBeVisible();
+  });
 
 });


### PR DESCRIPTION
### Test Case
TC_02.002.08 | Freestyle Project Configuration > Project Description > Verify description is displayed after Save

### What was done
- Added Playwright test to verify saved Freestyle project description
- Validated that description is displayed on the project Status page after Save

### Test result
- Passed locally using:
npx playwright test --ui

Closes (https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182891576&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C241)