### PR TITLE
TC_09.001.03 | Build history > Core Build History Display > Verify Build History displays list of builds

### DIFF
--- a/tests/tl-buildHistory.spec.ts
+++ b/tests/tl-buildHistory.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from "@/base";
+import { createFreestyleProject, newItemData } from "./testData/tl-data";
 
 test.describe("US_09.001 | Build History > Core Build History Display", () => {
   test("TC_09.001.02 | Verify Build History option is accessible from Dashboard", async ({ page }: { page: Page }) => {
@@ -6,4 +7,14 @@ test.describe("US_09.001 | Build History > Core Build History Display", () => {
 
     await expect(page).toHaveURL(/builds/);
   });
+
+  test("TC_09.001.03 | Verify Build History displays list of builds", async ({ page }: { page: Page }) => {
+    await createFreestyleProject(page, newItemData.freestyleProjectName);
+    await page.goto(`/job/${newItemData.freestyleProjectName}/`);
+    await page.getByRole("link", { name: "Build Now" }).click();
+    await expect(page.getByText("#1")).toBeVisible();   
+    
+    await expect(page.locator("#main-panel")).toContainText(newItemData.freestyleProjectName);
+  });
+
 });


### PR DESCRIPTION
### Test Case
TC_09.001.03 | Build history > Core Build History Display > Verify Build History displays list of builds

### What was done
- Added Playwright test to verify that Build History displays existing builds

### Test result
- Passed locally using:
npx playwright test --ui

Closes https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=183303261&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C292