### PR TITLE
TC_22.001.02 | Verify opening modal window by clicking "Add Credentials"

### DIFF
--- a/tests/ozh-addCredentialsFlow.spec.ts
+++ b/tests/ozh-addCredentialsFlow.spec.ts
@@ -1,10 +1,26 @@
-import { test, expect, Page } from '../base';
+import { test, expect, Page } from '@/base';
 import { manageCredentialsLocators, manageJenkinsLocators } from './testData/ozh-data';
 
-test.describe('US_22.001 | Add Credentials > General Flow', () => {
-  test('TC_22.001.01 | Verify that the Credentials page is accessible', async ({ page }) => {
+test.describe.serial('US_22.001 | Add Credentials > General Flow', () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto('/');
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('TC_22.001.01 | Verify that the Credentials page is accessible', async () => {
     await page.locator(manageJenkinsLocators.manageJenkinsBtn).click();
     await page.locator(manageCredentialsLocators.goToCredentialsBtn).click();
     await expect(page.locator(manageCredentialsLocators.addCredentialsBtn)).toBeVisible();
+  });
+
+  test('TC_22.001.02 | Verify opening modal window by clicking "Add Credentials"', async () => {
+    await page.locator(manageCredentialsLocators.addCredentialsBtn).click();
+    await expect(page.locator('.jenkins-dialog')).toBeVisible();
   });
 });


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/379
**Implementation note:**                                            
  Tests use **test.describe.serial** with a shared page instance declared via **let 
  page** in beforeAll. This allows each test to continue from where the previous   
  one left off, without repeating navigation steps.
                                                                                 
  **Important**: tests do not accept { page } as a parameter. If the Playwright page 
  fixture is added to a test's arguments, it will shadow the shared page variable
  and each test will start with a fresh page, breaking the chain.               