### PR TITLE
 TC_10.004.03 | Manage Jenkins > Tools > Verify Maven settings provider can be changed to custom

### DIFF
--- a/tests/vv-toolsConfiguration.spec.ts
+++ b/tests/vv-toolsConfiguration.spec.ts
@@ -2,20 +2,36 @@ import { test, expect, Page } from "@/base";
 import { vvData } from "./testData/vv-data";
 
 test.describe("US_10.004 | Manage Jenkins > Tools", () => {
-    test("TC_10.004.01 | Verify Tools Configuration Page opens", async ({ page }: { page: Page }) => {
+
+    test.beforeEach(async ({ page }: { page: Page }) => {
         await page.locator("a[href$='manage']").click();
         await page.locator("a[href$='configureTools']").click();
-        
+    });
+
+    test("TC_10.004.01 | Verify Tools Configuration Page opens", async ({ page }: { page: Page }) => {
         expect(page.url()).toContain("/configureTools");
         await expect(page.locator(".jenkins-breadcrumbs__list-item").filter({ hasText: "Tools" })).toBeVisible();
     });
 
     test("TC_10.004.02 | Verify Configuration sections are displayed", async ({ page }: { page: Page }) => {
-        await page.locator("a[href$='manage']").click();
-        await page.locator("a[href$='configureTools']").click();
-
         for (const section of vvData.toolsSections) {
             await expect(page.locator(".jenkins-section__title").filter({ hasText: section })).toBeVisible();
         }
+    });
+
+    test("TC_10.004.03 | Verify Maven settings provider can be changed to custom", async ({ page }: { page: Page }) => {
+        const settingsSelect = page
+            .locator('div.jenkins-form-item')
+            .filter({ hasText: 'Default settings provider' })
+            .locator('select');
+
+        await settingsSelect.selectOption('1');
+
+        const filePathInput = page
+            .locator('div.jenkins-form-item')
+            .filter({ hasText: 'File path' })
+            .locator('input');
+
+        await expect(filePathInput).toBeVisible();
     });
 });


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/410

1. Added new test "Verify Maven settings provider can be changed to custom"
2. Part of the code has been moved to the `test.beforeEach` block