### PR TITLE
TC_23.001.01_New_View_button_is_available_on_Dashboard

### DIFF
--- a/tests/ozh-createViewWithItems.spec.ts
+++ b/tests/ozh-createViewWithItems.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, Page } from '@/base';
+import { createNewItem, ozhJenkinsLocators } from './testData/ozh-data';
+import { cleanData } from '../helpers/cleanData';
+import { Locator } from '@playwright/test';
+
+test.describe.serial('US_23.001 | Global View > Create View with items with access', () => {
+  let page: Page;
+  let newViewBtn: Locator;
+
+  test.beforeAll(async ({ browser, request }) => {
+    await cleanData(request);
+    page = await browser.newPage();
+    await page.goto('/');
+
+    newViewBtn = page.locator('.tab a.addTab');
+
+    const itemsCount = await page.locator('tr.job').count();
+    if (itemsCount === 0) {
+      for (let i = 0; i < 4; i++) {
+        await createNewItem(page);
+        await page.locator(ozhJenkinsLocators.jenkinsLogo).click();
+      }
+      await page.goto('/');
+    }
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('TC_23.001.01 | A button for creating a new View is available on the Dashboard and has correct URL', async () => {
+    await expect(newViewBtn).toBeVisible();
+    await expect(newViewBtn).toHaveAttribute('href', '/newView');
+  });
+});

--- a/tests/ozh-createViewWithItems.spec.ts
+++ b/tests/ozh-createViewWithItems.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, Page } from '@/base';
 import { createNewItem, ozhJenkinsLocators } from './testData/ozh-data';
 import { cleanData } from '../helpers/cleanData';
 import { Locator } from '@playwright/test';
+import { faker } from '@faker-js/faker';
 
 test.describe.serial('US_23.001 | Global View > Create View with items with access', () => {
   let page: Page;
@@ -20,7 +21,7 @@ test.describe.serial('US_23.001 | Global View > Create View with items with acce
     const itemsCount = await page.locator('tr.job').count();
     if (itemsCount === 0) {
       for (let i = 0; i < 4; i++) {
-        await createNewItem(page);
+        await createNewItem(page, faker.word.noun() + i);
         await page.locator(ozhJenkinsLocators.jenkinsLogo).click();
       }
       await page.goto('/');

--- a/tests/ozh-createViewWithItems.spec.ts
+++ b/tests/ozh-createViewWithItems.spec.ts
@@ -9,7 +9,10 @@ test.describe.serial('US_23.001 | Global View > Create View with items with acce
 
   test.beforeAll(async ({ browser, request }) => {
     await cleanData(request);
-    page = await browser.newPage();
+    const context = await browser.newContext({
+      storageState: '.auth/storageState.json',
+    });
+    page = await context.newPage();
     await page.goto('/');
 
     newViewBtn = page.locator('.tab a.addTab');
@@ -25,7 +28,7 @@ test.describe.serial('US_23.001 | Global View > Create View with items with acce
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await page.context().close();
   });
 
   test('TC_23.001.01 | A button for creating a new View is available on the Dashboard and has correct URL', async () => {

--- a/tests/testData/ozh-data.ts
+++ b/tests/testData/ozh-data.ts
@@ -2,7 +2,7 @@ import { Page } from '../../base';
 import { faker } from '@faker-js/faker';
 
 export const ozData = {
-  itemName: faker.word.noun(),
+  jobName: faker.word.noun(),
   incorrectGitUrl: 'someurl',
   repoErrorMessage: 'Failed to connect to repository',
 };
@@ -13,7 +13,7 @@ export const ozhJenkinsLocators = {
   newFreestyleProject: '.hudson_model_FreeStyleProject',
   itemNameInput: 'input.jenkins-input#name',
   okBtn: 'button#ok-button',
-  itemPageLink: `a.jenkins-table__link[href*="job/${ozData.itemName}/"]`,
+  itemPageLink: `a.jenkins-table__link[href*="job/${ozData.jobName}/"]`,
   SCMButton: 'button[data-section-id=source-code-management]',
   repoUrlInput: 'input[name="_.url"]',
   repoUrlError: 'div[name="userRemoteConfigs"] .error',
@@ -42,7 +42,7 @@ export const credentials = [
   'Certificate',
 ];
 
-export async function createNewItem(page: Page, jobName: string = ozData.itemName): Promise<void> {
+export async function createNewItem(page: Page, jobName: string = ozData.jobName): Promise<void> {
   await page.locator(ozhJenkinsLocators.newJobBtn).click();
   await page.locator(ozhJenkinsLocators.itemNameInput).fill(jobName);
   await page.locator(ozhJenkinsLocators.newFreestyleProject).click();

--- a/tests/testData/ozh-data.ts
+++ b/tests/testData/ozh-data.ts
@@ -1,17 +1,19 @@
 import { Page } from '../../base';
+import { faker } from '@faker-js/faker';
+
 export const ozData = {
-  jobName: 'TestJob',
+  itemName: faker.word.noun(),
   incorrectGitUrl: 'someurl',
   repoErrorMessage: 'Failed to connect to repository',
 };
 
 export const ozhJenkinsLocators = {
   jenkinsLogo: 'a.app-jenkins-logo',
-  newJobBtn: 'a[href="newJob"]',
+  newJobBtn: 'a[href="/view/all/newJob"]',
   newFreestyleProject: '.hudson_model_FreeStyleProject',
   itemNameInput: 'input.jenkins-input#name',
   okBtn: 'button#ok-button',
-  itemPageLink: `a.jenkins-table__link[href*="job/${ozData.jobName}/"]`,
+  itemPageLink: `a.jenkins-table__link[href*="job/${ozData.itemName}/"]`,
   SCMButton: 'button[data-section-id=source-code-management]',
   repoUrlInput: 'input[name="_.url"]',
   repoUrlError: 'div[name="userRemoteConfigs"] .error',
@@ -40,9 +42,9 @@ export const credentials = [
   'Certificate',
 ];
 
-export async function createNewItem(page: Page): Promise<void> {
+export async function createNewItem(page: Page, jobName: string = ozData.itemName): Promise<void> {
   await page.locator(ozhJenkinsLocators.newJobBtn).click();
-  await page.locator(ozhJenkinsLocators.itemNameInput).fill(ozData.jobName);
+  await page.locator(ozhJenkinsLocators.itemNameInput).fill(jobName);
   await page.locator(ozhJenkinsLocators.newFreestyleProject).click();
   await page.locator(ozhJenkinsLocators.okBtn).click();
   await page.waitForLoadState('networkidle');


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/404

Tests use **test.describe.seria**l with a shared page instance declared via **let page** in  **beforeAll**. 
_This allows each test to continue from where the previous one left off, without repeating navigation steps._                                                     

 Since **browser.newPage()** bypasses the custom **base.ts fixture** (which handles auth via storageState), the context is created manually with **storageState: 
 '.auth/storageState.json'** to preserve the authenticated session.                        
                                                   
  **afterAll** closes the context instead of the page directly, which also closes all pages within it.