### PR TITLE
TC_05.001.07 | Folder Configuration > Display Name and Description > Verify empty Display Name and Description can be saved

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -9,6 +9,14 @@ export const generateProjectName = (): string => {
   return `test-${faker.string.alphanumeric(5)}`;
 };
 
+export const generateDisplayName = (): string => {
+  return faker.company.name();
+};
+
+export const generateDescription = (): string => {
+  return faker.lorem.sentence();
+};
+
 export const newItemData = {
   invalidItemName: "test?item",
   freestyleProjectName: "test-freestyle-project",

--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@/base";
-import { commonLocators, createFolder, folderConfigData, folderConfigLocators } from "./testData/tl-data";
+import { commonLocators, createFolder, folderConfigData, folderConfigLocators, generateDescription, generateDisplayName } from "./testData/tl-data";
 
 test.describe("US_05.001 | Folder Configuration > Display Name and Description", () => {
 
@@ -46,6 +46,24 @@ test.describe("US_05.001 | Folder Configuration > Display Name and Description",
     await page.locator(commonLocators.submitButton).click();
 
     await expect(page.locator("#main-panel").getByText(folderConfigData.updatedDescription, { exact: true })).toBeVisible();
+  });
+
+  test("TC_05.001.07 | Verify empty Display Name and Description can be saved", async ({ page }: { page: Page }) => {
+    await createFolder(page, folderConfigData.folderName);
+
+    await page.goto(`/job/${folderConfigData.folderName}/configure`);
+
+    await page.locator("input[name='_.displayNameOrNull']").fill(generateDisplayName());
+    await page.locator("textarea").fill(generateDescription());
+    await page.locator(commonLocators.submitButton).click();
+
+    await page.getByRole("link", { name: "Configure" }).click();
+
+    await page.locator("input[name='_.displayNameOrNull']").clear();
+    await page.locator("textarea").clear();
+    await page.locator(commonLocators.submitButton).click();
+    
+    await expect(page.getByRole("link", { name: "Configure" })).toBeVisible();
   });
 
 });


### PR DESCRIPTION
### Test Case
TC_05.001.07 | Folder Configuration > Display Name and Description > Verify empty Display Name and Description can be saved

- Passed locally 

Closes https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182885722&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C232