### PR TITLE
TC_01.005.06 | New Item > Multibranch Pipeline > Verify user can return to Dashboard without creating item

### DIFF
--- a/tests/testData/tl-data.ts
+++ b/tests/testData/tl-data.ts
@@ -3,6 +3,7 @@ import { faker } from "@faker-js/faker";
 
 export const commonLocators = {
   submitButton: "button[name='Submit']",
+  jenkinsLogo: ".app-jenkins-logo",
 };
 
 export const generateProjectName = (): string => {

--- a/tests/tl-multibranchPipeline.spec.ts
+++ b/tests/tl-multibranchPipeline.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@/base";
-import { generateProjectName, newItemLocators, openNewItemPage } from "./testData/tl-data";
+import { commonLocators, generateProjectName, newItemLocators, openNewItemPage } from "./testData/tl-data";
 
 test.describe("US_01.005 | New Item > Multibranch Pipeline ", () => {
   test("TC_01.005.03 | Verify Multibranch Pipeline type is displayed", async ({ page }: { page: Page }) => {
@@ -32,6 +32,17 @@ test.describe("US_01.005 | New Item > Multibranch Pipeline ", () => {
     await page.getByText("Multibranch Pipeline").click();
 
     await expect(page.locator(newItemLocators.okButton)).toBeEnabled();
+  });
+
+  test("TC_01.005.06 | Verify user can return to Dashboard without creating item", async ({ page }: { page: Page }) => {
+    const dashboardItems = page.locator(".jenkins-table__link.model-link.inside");
+    const beforeNewItem = await dashboardItems.allTextContents();
+
+    await openNewItemPage(page);
+    await page.locator(commonLocators.jenkinsLogo).click();
+
+    const afterNewItem = await dashboardItems.allTextContents();
+    expect(afterNewItem).toEqual(beforeNewItem);
   });
   
 });

--- a/tests/tl-multibranchPipeline.spec.ts
+++ b/tests/tl-multibranchPipeline.spec.ts
@@ -35,14 +35,14 @@ test.describe("US_01.005 | New Item > Multibranch Pipeline ", () => {
   });
 
   test("TC_01.005.06 | Verify user can return to Dashboard without creating item", async ({ page }: { page: Page }) => {
-    const dashboardItems = page.locator(".jenkins-table__link.model-link.inside");
-    const beforeNewItem = await dashboardItems.allTextContents();
+    const dashboardProjectLinks = page.locator(".jenkins-table__link.model-link.inside");
+    const beforeProjectLinksTexts = await dashboardProjectLinks.allTextContents();
 
     await openNewItemPage(page);
     await page.locator(commonLocators.jenkinsLogo).click();
 
-    const afterNewItem = await dashboardItems.allTextContents();
-    expect(afterNewItem).toEqual(beforeNewItem);
+    const afterProjectLinksTexts = await dashboardProjectLinks.allTextContents();
+
+    expect(afterProjectLinksTexts).toEqual(beforeProjectLinksTexts);
   });
-  
 });


### PR DESCRIPTION
### Test Case
TC_01.005.06 | New Item > Multibranch Pipeline > Verify user can return to Dashboard without creating item

### What was done
- Added Playwright test to verify returning to Jenkins Dashboard without creating an item
- Captured Dashboard item list before opening New Item page
- Returned to Dashboard using Jenkins logo
- Verified that no new item was created by comparing Dashboard items before and after navigation

### Test result
- Passed locally using:
npx playwright test --ui

Closes https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=183319370&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C327