### PR TITLE
TC_05.004.03 | Folder Configuration > Save or Apply > Verify Apply persists changes without redirecting

### DIFF
--- a/tests/tl-folderConfiguration.spec.ts
+++ b/tests/tl-folderConfiguration.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, Page } from "@/base";
 import { commonLocators, createFolder, folderConfigData, folderConfigLocators, generateDescription, generateDisplayName } from "./testData/tl-data";
-import { description } from "./testData/ok-data";
 
 test.describe("US_05.001 | Folder Configuration > Display Name and Description", () => {
 
@@ -105,5 +104,17 @@ test.describe("US_05.004 | Folder Configuration > Save or Apply", () => {
     await page.locator(commonLocators.submitButton).click();
 
     await expect(page.getByText(description)).toBeVisible();
+  });
+
+  test("TC_05.004.03 | Verify Apply persists changes without redirecting", async ({ page }: { page: Page }) => {
+    const description = generateDescription();
+    
+    await createFolder(page);
+    await page.getByRole("link", { name: "Configure" }).click();
+
+    await page.locator("textarea").fill(description);
+    await page.locator(commonLocators.applyButton).click();
+
+    await expect(page.locator("textarea")).toHaveValue(description);
   });
 });


### PR DESCRIPTION
### Test Case
TC_05.004.03 | Folder Configuration > Save or Apply > Verify Apply persists changes without redirecting

### What was done
- Added Playwright test for Folder configuration Apply functionality
- Opened Folder configuration page
- Updated Description field
- Clicked Apply button
- Verified that Description value remains in the field without redirecting from configuration page

### Test result
- Passed locally using:
npx playwright test --ui

Closes https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=182889731&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C236