### PR TITLE
TC_09.001.06 | Build history > Core Build History Display > Verify build number links to Build Summary page

### DIFF
--- a/tests/tl-buildHistory.spec.ts
+++ b/tests/tl-buildHistory.spec.ts
@@ -57,11 +57,9 @@ test.describe("US_09.001 | Build History > Core Build History Display", () => {
     const buildLink = page.locator("#trend tbody tr td:nth-child(2) a").first();
 
     const buildNumber = await buildLink.textContent();
+    const buildId = buildNumber?.replace("#", "");
 
-    await buildLink.focus();
-    await page.keyboard.press("Enter");
-
-    await expect(page.getByRole("heading")).toContainText(buildNumber!);
+    await expect(buildLink).toHaveAttribute("href", new RegExp(`${buildId}/?$`));
   });
 });
 

--- a/tests/tl-buildHistory.spec.ts
+++ b/tests/tl-buildHistory.spec.ts
@@ -47,6 +47,22 @@ test.describe("US_09.001 | Build History > Core Build History Display", () => {
 
     await expect(successIcon).toBeVisible();
   });
+
+  test("TC_09.001.06 | Verify build number links to Build Summary page", async ({ page }: { page: Page }) => {
+    await createFreestyleProject(page);
+    await createBuilds(page, 1);
+
+    await page.locator(".jenkins-card__title-link.jenkins-card__reveal").click();
+
+    const buildLink = page.locator("#trend tbody tr td:nth-child(2) a").first();
+
+    const buildNumber = await buildLink.textContent();
+
+    await buildLink.focus();
+    await page.keyboard.press("Enter");
+
+    await expect(page.getByRole("heading")).toContainText(buildNumber!);
+  });
 });
 
 test.describe("US_09.002 | Build History > Sorting", () => {


### PR DESCRIPTION
### Test Case
TC_09.001.06 | Build history > Core Build History Display > Verify build number links to Build Summary page

### Note
Used keyboard navigation (`focus + Enter`) because standard mouse click on the build entry opens the Jenkins dropdown menu instead of navigating to the Build Summary page.

### Test result
- Passed locally using:
npx playwright test --ui

Closes https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=183303854&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C295