### PR TITLE
RF_01.001.22 | New Item > Create a new item > Verify blank item name validation

### DIFF
--- a/POM/pageObjects/pages/NewItemPage.ts
+++ b/POM/pageObjects/pages/NewItemPage.ts
@@ -3,6 +3,7 @@ import { BasePage } from "./@components";
 export class NewItemPage extends BasePage {
 	itemNameField = () => this.page.locator("#name");
 	itemType_FreestyleProject = () => this.page.locator(".hudson_model_FreeStyleProject");
+	nameValidationMessage = () => this.page.locator("#itemname-required");
 	// itemType_Pipeline = () =>
 	okButton = () => this.page.locator("#ok-button");
 

--- a/POM/tests/HomePage.spec.ts
+++ b/POM/tests/HomePage.spec.ts
@@ -13,4 +13,10 @@ test.describe("US_01.001 | New Item > Create a new item", () => {
 
 		await expect(app.homePage.itemName()).toHaveText(newItemPageData.itemName);
 	});
+
+	test("RF_01.001.22 | New Item > Create a new item > Verify blank item name validation", async ({ app }: { app: App }) => {
+		await app.homePage.clickNewItemLink();
+
+  		await expect(app.newItemPage.nameValidationMessage()).toContainText("This field cannot be empty");	
+	});
 });

--- a/POM/tests/HomePage.spec.ts
+++ b/POM/tests/HomePage.spec.ts
@@ -13,12 +13,6 @@ test.describe('US_01.001 | New Item > Create a new item', () => {
 
 		await expect(app.homePage.itemName()).toHaveText(newItemPageData.itemName);
 	});
-
-	test("RF_01.001.22 | New Item > Create a new item > Verify blank item name validation", async ({ app }: { app: App }) => {
-		await app.homePage.clickNewItemLink();
-
-  	await expect(app.newItemPage.itemNameValidationMessage()).toContainText("This field cannot be empty");	
-	});
 });
 
 test.describe('US_16.008 | Freestyle Project Management', () => {

--- a/POM/tests/NewItemPage.spec.ts
+++ b/POM/tests/NewItemPage.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect, App } from '@/POM/fixtures/baseFixtures';
+
+test.describe('US_01.001 | New Item > Create a new item', () => {
+	test("RF_01.001.22 | New Item > Create a new item > Verify blank item name validation", async ({ app }: { app: App }) => {
+		await app.homePage.clickNewItemLink();
+
+  	await expect(app.newItemPage.itemNameValidationMessage()).toContainText("This field cannot be empty");	
+	});
+});

--- a/POM/tests/NewItemPage.spec.ts
+++ b/POM/tests/NewItemPage.spec.ts
@@ -4,6 +4,6 @@ test.describe('US_01.001 | New Item > Create a new item', () => {
 	test("RF_01.001.22 | New Item > Create a new item > Verify blank item name validation", async ({ app }: { app: App }) => {
 		await app.homePage.clickNewItemLink();
 
-  	await expect(app.newItemPage.itemNameValidationMessage()).toContainText("This field cannot be empty");	
+  		await expect(app.newItemPage.itemNameValidationMessage()).toContainText("This field cannot be empty");	
 	});
 });


### PR DESCRIPTION
#### Description:

Convert existing test to POM.

#### What have changed:

- Use existing POM structure
- Move validation message locator to NewItemPage
- Refactor spec to use `app` fixture

#### Acceptance Criteria:

Test has been converted to POM and still passes validation and CI.