### PR TITLE
Fix flaky clickItemNameLink to avoid chevron drodown

### DIFF
--- a/POM/pageObjects/pages/HomePage.ts
+++ b/POM/pageObjects/pages/HomePage.ts
@@ -12,6 +12,6 @@ export class HomePage extends BasePage {
   }
 
   async clickItemNameLink() {
-    await this.itemName().click();
+    await this.itemName().dispatchEvent('click');
   }
 }

--- a/POM/pageObjects/pages/HomePage.ts
+++ b/POM/pageObjects/pages/HomePage.ts
@@ -12,6 +12,7 @@ export class HomePage extends BasePage {
   }
 
   async clickItemNameLink() {
-    await this.itemName().click({ position: { x: 0, y: 0 } });
+    await this.itemName().focus();
+    await this.itemName().press('Enter');
   }
 }

--- a/POM/pageObjects/pages/HomePage.ts
+++ b/POM/pageObjects/pages/HomePage.ts
@@ -12,6 +12,6 @@ export class HomePage extends BasePage {
   }
 
   async clickItemNameLink() {
-    await this.itemName().dispatchEvent('click');
+    await this.itemName().click({ position: { x: 0, y: 0 } });
   }
 }


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/540

исправила нестабильный клик по ссылке проекта — использую focus() + press('Enter') чтобы избежать появления chevron дропдауна