### PR TITLE
RF_01.001.25 | New Item > Create a new item > Verify warning for duplicate item name

### DIFF
--- a/POM/pageObjects/App.ts
+++ b/POM/pageObjects/App.ts
@@ -8,7 +8,6 @@ import { ToolsPage } from "./pages/ToolsPage";
 import { PluginsPage } from "./pages/PluginsPage";
 import { FolderPage } from "./pages/FolderPage";
 import { ConfigureFolderPage } from "./pages/ConfigureFolderPage";
-import { Header } from "./pages/@components/Header";
 
 export class App {
   private _homePage: HomePage | null = null;
@@ -20,7 +19,6 @@ export class App {
   private _manageJenkinsPage: ManageJenkinsPage | null = null;
   private _toolsPage: ToolsPage | null = null;
   private _pluginsPage: PluginsPage | null = null;
-  private _header: Header | null = null;
 
   constructor(private readonly page: Page) {}
 
@@ -59,9 +57,5 @@ export class App {
 
   get pluginsPage() {
     return (this._pluginsPage ??= new PluginsPage(this.page));
-  }
-
-  get header() {
-    return (this._header ??= new Header(this.page));
   }
 }

--- a/POM/pageObjects/App.ts
+++ b/POM/pageObjects/App.ts
@@ -8,6 +8,7 @@ import { ToolsPage } from "./pages/ToolsPage";
 import { PluginsPage } from "./pages/PluginsPage";
 import { FolderPage } from "./pages/FolderPage";
 import { ConfigureFolderPage } from "./pages/ConfigureFolderPage";
+import { Header } from "./pages/@components/Header";
 
 export class App {
   private _homePage: HomePage | null = null;
@@ -19,6 +20,7 @@ export class App {
   private _manageJenkinsPage: ManageJenkinsPage | null = null;
   private _toolsPage: ToolsPage | null = null;
   private _pluginsPage: PluginsPage | null = null;
+  private _header: Header | null = null;
 
   constructor(private readonly page: Page) {}
 
@@ -57,5 +59,9 @@ export class App {
 
   get pluginsPage() {
     return (this._pluginsPage ??= new PluginsPage(this.page));
+  }
+
+  get header() {
+    return (this._header ??= new Header(this.page));
   }
 }

--- a/POM/pageObjects/pages/NewItemPage.ts
+++ b/POM/pageObjects/pages/NewItemPage.ts
@@ -8,6 +8,8 @@ export class NewItemPage extends BasePage {
   itemType_Folder = () =>
     this.page.locator(".com_cloudbees_hudson_plugins_folder_Folder");
   itemNameValidationMessage = () => this.page.locator("#itemname-required");
+  duplicateItemNameWarning = () =>
+    this.page.getByText("A job already exists with the name");
   // itemType_Pipeline = () =>
   okButton = () => this.page.locator("#ok-button");
 
@@ -33,5 +35,12 @@ export class NewItemPage extends BasePage {
 
   async clickOkButton() {
     await this.okButton().click();
+  }
+
+  async createFreestyleProject(name: string) {
+    await this.fillItemNameField(name);
+    await this.clickFreestyleProject();
+    await this.clickOkButton();
+    return this;
   }
 }

--- a/POM/pageObjects/pages/NewItemPage.ts
+++ b/POM/pageObjects/pages/NewItemPage.ts
@@ -41,6 +41,5 @@ export class NewItemPage extends BasePage {
     await this.fillItemNameField(name);
     await this.clickFreestyleProject();
     await this.clickOkButton();
-    return this;
   }
 }

--- a/POM/testData/newItemPageData.ts
+++ b/POM/testData/newItemPageData.ts
@@ -9,6 +9,7 @@ export const newItemPageData = {
     multiConfigurationProject: "Multi-configuration project",
     folder: "Folder",
     multibranchPipeline: "Multibranch Pipeline",
-    organizationFolder: "Organization Folder"
-  }
+    organizationFolder: "Organization Folder",
+  },
+  duplicateItemName: `duplicate-${faker.string.alphanumeric(8)}`,
 };

--- a/POM/tests/NewItemPage.spec.ts
+++ b/POM/tests/NewItemPage.spec.ts
@@ -1,15 +1,38 @@
-import { test, expect, App } from '@/POM/fixtures/baseFixtures';
+import { test, expect, App } from "@/POM/fixtures/baseFixtures";
+import { newItemPageData } from "@/POM/testData/newItemPageData";
 
-test.describe('US_01.001 | New Item > Create a new item', () => {
-	test("RF_01.001.21 | New Item > Create a new item > Verify new item page opens from dashboard", async ({ app }: { app: App }) => {
-  		await app.homePage.clickNewItemLink();
+test.describe("US_01.001 | New Item > Create a new item", () => {
+  test("RF_01.001.21 | Verify new item page opens from dashboard", async ({
+    app,
+  }: {
+    app: App;
+  }) => {
+    await app.homePage.clickNewItemLink();
 
-  		await expect(app.newItemPage.newItemTitle()).toContainText("New Item");
-	});
-    
-	test("RF_01.001.22 | New Item > Create a new item > Verify blank item name validation", async ({ app }: { app: App }) => {
-		await app.homePage.clickNewItemLink();
+    await expect(app.newItemPage.newItemTitle()).toContainText("New Item");
+  });
 
-  		await expect(app.newItemPage.itemNameValidationMessage()).toContainText("This field cannot be empty");	
-	});
+  test("RF_01.001.25 | Verify warning for duplicate item name", async ({
+    app,
+  }: {
+    app: App;
+  }) => {
+    const itemName = newItemPageData.duplicateItemName;
+
+    await app.homePage.clickNewItemLink();
+
+    await app.newItemPage.createFreestyleProject(itemName);
+
+    await app.header.clickHome();
+
+    await app.homePage.clickNewItemLink();
+
+    await app.newItemPage.fillItemNameField(itemName);
+
+    await app.newItemPage.clickFreestyleProject();
+
+    await expect(app.newItemPage.duplicateItemNameWarning()).toContainText(
+      itemName,
+    );
+  });
 });

--- a/POM/tests/NewItemPage.spec.ts
+++ b/POM/tests/NewItemPage.spec.ts
@@ -12,6 +12,18 @@ test.describe("US_01.001 | New Item > Create a new item", () => {
     await expect(app.newItemPage.newItemTitle()).toContainText("New Item");
   });
 
+  test("RF_01.001.22 | Verify blank item name validation", async ({
+    app,
+  }: {
+    app: App;
+  }) => {
+    await app.homePage.clickNewItemLink();
+
+    await expect(app.newItemPage.itemNameValidationMessage()).toContainText(
+      "This field cannot be empty",
+    );
+  });
+
   test("RF_01.001.25 | Verify warning for duplicate item name", async ({
     app,
   }: {

--- a/POM/tests/NewItemPage.spec.ts
+++ b/POM/tests/NewItemPage.spec.ts
@@ -23,7 +23,7 @@ test.describe("US_01.001 | New Item > Create a new item", () => {
 
     await app.newItemPage.createFreestyleProject(itemName);
 
-    await app.header.clickHome();
+    await app.newItemPage.header.clickHome();
 
     await app.homePage.clickNewItemLink();
 

--- a/POM/tests/NewItemPage.spec.ts
+++ b/POM/tests/NewItemPage.spec.ts
@@ -23,7 +23,7 @@ test.describe("US_01.001 | New Item > Create a new item", () => {
 
     await app.newItemPage.createFreestyleProject(itemName);
 
-    await app.newItemPage.header.clickHome();
+    await app.configureFreestylePage.header.clickHome();
 
     await app.homePage.clickNewItemLink();
 


### PR DESCRIPTION
Refactor duplicate item warning test to POM.

What was changed:
- moved duplicate warning locator to NewItemPage
- added reusable createFreestyleProject method
- refactored test to use app fixture
- improved locator stability

Test passes locally and in UI mode.