### PR TITLE
TC_02.004.02 | Verify "Projects to watch" field is displayed and enabled when "Build after other projects are built" is selected

### DIFF
--- a/POM/pageObjects/pages/ConfigureFreestylePage.ts
+++ b/POM/pageObjects/pages/ConfigureFreestylePage.ts
@@ -8,6 +8,11 @@ export class ConfigureFreestylePage extends BasePage {
   authTokenField = () => this.page.locator('input[name="authToken"]');
   triggerBuildsRemotelyCheckbox = () =>
     this.page.locator("label.attach-previous").filter({ hasText: "Trigger builds remotely" });
+  buildAfterOtherProjectsCheckBox = () =>
+    this.page
+      .locator("label.attach-previous")
+      .filter({ hasText: "Build after other projects are built" });
+  projectsToWatchInput = () => this.page.locator('input[name="_.upstreamProjects"]');
 
   async disableProject() {
     await this.enableProjectSwitcher().uncheck();
@@ -15,7 +20,7 @@ export class ConfigureFreestylePage extends BasePage {
   }
   async saveChanges() {
     await this.saveChangesBtn().click();
-    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.waitForLoadState("domcontentloaded");
   }
 
   async goToTriggersSection() {
@@ -25,6 +30,11 @@ export class ConfigureFreestylePage extends BasePage {
 
   async enableTriggerBuildsRemotely() {
     await this.triggerBuildsRemotelyCheckbox().click();
+    return this;
+  }
+
+  async enableBuildAfterOtherProjectsCheckBox() {
+    await this.buildAfterOtherProjectsCheckBox().click();
     return this;
   }
 }

--- a/POM/tests/ConfigureFreestyleProject.spec.ts
+++ b/POM/tests/ConfigureFreestyleProject.spec.ts
@@ -28,4 +28,15 @@ test.describe("US_02.004 | Freestyle Project Configuration > Build Triggers", ()
     await expect(app.configureFreestylePage.authTokenField()).toBeVisible();
     await expect(app.configureFreestylePage.authTokenField()).toBeEnabled();
   });
+
+  test(`TC_02.004.02 | Verify "Projects to watch" field is displayed and enabled when "Build after other projects are built" is selected`, async ({
+    app,
+  }: {
+    app: App;
+  }) => {
+    await app.configureFreestylePage.enableBuildAfterOtherProjectsCheckBox();
+
+    await expect(app.configureFreestylePage.projectsToWatchInput()).toBeVisible();
+    await expect(app.configureFreestylePage.projectsToWatchInput()).toBeEnabled();
+  });
 });


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_JS_2026_spring/issues/594