### PR TITLE
RF_10.005.01 | Renaming PluginsPage to PluginManagerPage

### DIFF
--- a/POM/pageObjects/App.ts
+++ b/POM/pageObjects/App.ts
@@ -9,7 +9,7 @@ import { ManageJenkinsPage } from "./pages/ManageJenkinsPage";
 import { ToolsPage } from "./pages/ToolsPage";
 import { BuildHistoryPage } from "./pages/BuildHistoryPage";
 import { Header } from "./pages/@components/Header";
-import { PluginsPage } from "./pages/PluginsPage";
+import { PluginManagerPage } from "./pages/PluginManagerPage";
 import { FolderPage } from "./pages/FolderPage";
 import { ConfigureFolderPage } from "./pages/ConfigureFolderPage";
 import { ConfigurePipelinePage } from "./pages/ConfigurePipelinePage";
@@ -29,7 +29,7 @@ export class App {
     private _toolsPage: ToolsPage | null = null;
     private _buildHistoryPage: BuildHistoryPage | null = null;
     private _header: Header | null = null;
-    private _pluginsPage: PluginsPage | null = null;
+    private _pluginManagerPage: PluginManagerPage | null = null;
     private _configurePipelinePage: ConfigurePipelinePage | null = null;
     private _configureOrganizationFolderPage: ConfigureOrganizationFolderPage | null = null;
     private _configureMultibranchPipelinePage: ConfigureMultibranchPipelinePage | null = null;
@@ -81,8 +81,8 @@ export class App {
         return (this._statusPage ??= new StatusPage(this.page));
     }
 
-    get pluginsPage() {
-        return (this._pluginsPage ??= new PluginsPage(this.page));
+    get pluginManagerPage() {
+        return (this._pluginManagerPage ??= new PluginManagerPage(this.page));
     }
 
     get configurePipelinePage() {

--- a/POM/pageObjects/pages/PluginManagerPage.ts
+++ b/POM/pageObjects/pages/PluginManagerPage.ts
@@ -1,6 +1,6 @@
 import { BasePage } from "./@components";
 
-export class PluginsPage extends BasePage {
+export class PluginManagerPage extends BasePage {
         
     // locators
     mainTitle = () => this.page.getByRole('heading', { name: 'Plugins' });

--- a/POM/tests/ManageJenkinsPage.spec.ts
+++ b/POM/tests/ManageJenkinsPage.spec.ts
@@ -1,31 +1,19 @@
 import { test, expect, App } from "@/POM/fixtures/baseFixtures";
 import { manageJenkinsPageData } from "../testData/jenkinsData";
 
-test.describe("US_10.005 | Manage Jenkins > Plugins > Updates", () => {
+test.describe("US_10 | Manage Jenkins ", () => {
   test("RF_10.005.01 | Verify user can access Plugins section", async ({ app }: { app: App }) => {
     await app.homePage.header.clickManageJenkins();
     await app.manageJenkinsPage.clickPlugins();
 
-    await expect(app.pluginsPage.mainTitle()).toBeVisible();
+    await expect(app.pluginManagerPage.mainTitle()).toBeVisible();
   });
-  test.describe("US_10.005 | Manage Jenkins > Plugins > Updates", () => {
-    test("RF_10.005.01 | Verify user can access Plugins section", async ({ app }: { app: App }) => {
-      await app.homePage.header.clickManageJenkins();
-      await app.manageJenkinsPage.clickPlugins();
 
-      await expect(app.pluginsPage.mainTitle()).toBeVisible();
-    });
+  test("RF_10.005.02 | Verify 'Updates' option is available in the left side-menu", async ({ app }: { app: App }) => {
+    await app.homePage.header.clickManageJenkins();
+    await app.manageJenkinsPage.clickPlugins();
 
-    test("RF_10.005.02 | Verify 'Updates' option is available in the left side-menu", async ({
-      app,
-    }: {
-      app: App;
-    }) => {
-      await app.homePage.header.clickManageJenkins();
-      await app.manageJenkinsPage.clickPlugins();
-
-      await expect(app.pluginsPage.updatesTaskLink()).toBeVisible();
-    });
+    await expect(app.pluginManagerPage.updatesTaskLink()).toBeVisible();
   });
 });
 


### PR DESCRIPTION
[№659](https://github.com/orgs/RedRoverSchool/projects/16/views/2?filterQuery=assignee%3A1user11&pane=issue&itemId=189671799&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C659)