### PR TITLE
RF_09.001.03 | Verify Build History displays list of builds

### DIFF
--- a/POM/tests/BuildHistoryPage.spec.ts
+++ b/POM/tests/BuildHistoryPage.spec.ts
@@ -2,6 +2,52 @@ import { test, expect, App } from "@/POM/fixtures/baseFixtures";
 import { newItemPageData } from "@/POM/testData/newItemPageData";
 
 test.describe("US_09.001 | Build history > Core Build History Display", () => {
+    test("RF_09.001.01 | Item displays on Build History page after building", async ({
+        app,
+    }) => {
+        await app.homePage.clickNewItemLink();
+        await app.newItemPage.fillItemNameField(newItemPageData.itemName);
+        await app.newItemPage.clickFreestyleProject();
+        await app.newItemPage.clickOkButton();
+
+        await app.configureFreestylePage.saveChanges();
+        await app.statusFreestyleProjectPage.clickBuildNowLink();
+        await app.statusFreestyleProjectPage.header.clickHome();
+        await app.homePage.clickBuildHistoryLink();
+
+        await expect(app.buildHistoryPage.newItemName()).toContainText(
+            newItemPageData.itemName,
+        );
+    });
+
+    test("RF_09.001.03 | Verify Build History displays list of builds", async ({
+        app,
+    }: {
+        app: App;
+    }) => {
+        const projectName = newItemPageData.itemName;
+        const expectedBuildNumbers = ["#3", "#2", "#1"];
+
+        await app.homePage.clickNewItemLink();
+        await app.newItemPage.createFreestyleProject(projectName);
+        await app.configureFreestylePage.clickSaveButton();
+
+        await app.statusFreestyleProjectPage.createBuilds(
+            expectedBuildNumbers.length,
+        );
+
+        await app.statusFreestyleProjectPage.header.clickHome();
+        await app.homePage.clickBuildHistoryLink();
+
+        await expect(app.buildHistoryPage.buildValues()).toHaveCount(
+            expectedBuildNumbers.length,
+        );
+
+        await expect(app.buildHistoryPage.buildValues()).toHaveText(
+            expectedBuildNumbers,
+        );
+    });
+
     test("RF_09.001.05 | Verify successful build entry displays success status icon", async ({
         app,
     }) => {
@@ -45,24 +91,6 @@ test.describe("US_09.001 | Build history > Core Build History Display", () => {
         await expect(
             app.buildHistoryPage.firstBuildNumberLink(),
         ).toHaveAttribute("href", new RegExp(`${buildId}/?$`));
-    });
-
-    test("RF_09.001.01 | Item displays on Build History page after building", async ({
-        app,
-    }) => {
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.fillItemNameField(newItemPageData.itemName);
-        await app.newItemPage.clickFreestyleProject();
-        await app.newItemPage.clickOkButton();
-
-        await app.configureFreestylePage.saveChanges();
-        await app.statusFreestyleProjectPage.clickBuildNowLink();
-        await app.statusFreestyleProjectPage.header.clickHome();
-        await app.homePage.clickBuildHistoryLink();
-
-        await expect(app.buildHistoryPage.newItemName()).toContainText(
-            newItemPageData.itemName,
-        );
     });
 });
 


### PR DESCRIPTION
## Summary

Refactored Build History list display test to current POM structure.

## Changes

- Added Build History list display verification test
- Reused existing StatusFreestyleProjectPage build actions
- Reused existing BuildHistoryPage locators/actions
- Verified multiple build entries are displayed
- Reduced hardcoded values using test data and dynamic build count

## Validation

- Test passed locally
- Related tests passed locally
- Test aligned with current Build History POM architecture

https://github.com/orgs/RedRoverSchool/projects/16/views/2?filterQuery=assignee%3Alindertat&pane=issue&itemId=190192534&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C668