### PR TITLE
RF_05 | Folder Configuration > Consolidate spec structure and stabilize tests

### DIFF
--- a/POM/pageObjects/App.ts
+++ b/POM/pageObjects/App.ts
@@ -13,6 +13,7 @@ import { ConfigurePipelinePage } from "./pages/ConfigurePipelinePage";
 import { ConfigureOrganizationFolderPage } from "@/POM/pageObjects/pages/ConfigureOrganizationFolderPage";
 import { ConfigureMultibranchPipelinePage } from "./pages/ConfigureMulribranchPipelinePage";
 import { StatusFreestyleProjectPage } from "@/POM/pageObjects/pages/StatusFreestyleProjectPage";
+import { StatusFolderPage } from "./pages/StatusFolderPage";
 
 export class App {
     private _homePage: HomePage | null = null;
@@ -31,6 +32,7 @@ export class App {
         null;
     private _statusFreestyleProjectPage: StatusFreestyleProjectPage | null =
         null;
+    private _statusFolderPage: StatusFolderPage | null = null;
 
     constructor(private readonly page: Page) {}
 
@@ -115,5 +117,9 @@ export class App {
         const results = await builder.analyze();
 
         return results.violations;
+    }
+
+    get statusFolderPage() {
+        return (this._statusFolderPage ??= new StatusFolderPage(this.page));
     }
 }

--- a/POM/pageObjects/pages/ConfigureFolderPage.ts
+++ b/POM/pageObjects/pages/ConfigureFolderPage.ts
@@ -1,48 +1,56 @@
 import { BasePage } from "./@components";
 
 export class ConfigureFolderPage extends BasePage {
-  propertiesButton = () =>
-    this.page.locator("button[data-section-id='properties']");
-  addButton = () => this.page.locator(".jenkins-button.repeatable-add");
-  libraryInputField = () =>
-    this.page.locator(".setting-main input[checkdependson='name']");
-  generalSection = () => this.page.locator("#general");
-  submitButton = () => this.page.locator("button[name='Submit']");
-  displayNameInput = () =>
-    this.page.locator('input[name="_.displayNameOrNull"]');
-  descriptionInput = () => this.page.locator(".setting-main textarea");
-  applyButton = () => this.page.locator('button[name="Apply"]');
+    propertiesButton = () =>
+        this.page.locator("button[data-section-id='properties']");
+    addButton = () => this.page.locator(".jenkins-button.repeatable-add");
+    libraryInputField = () =>
+        this.page.locator(".setting-main input[checkdependson='name']");
+    generalSection = () => this.page.locator("#general");
+    submitButton = () => this.page.locator("button[name='Submit']");
+    displayNameInput = () =>
+        this.page.locator('input[name="_.displayNameOrNull"]');
+    descriptionInput = () => this.page.locator(".setting-main textarea");
+    applyButton = () => this.page.locator('button[name="Apply"]');
+    pipelineLibrariesButton = () =>
+        this.page.locator("button[data-section-id='pipeline-libraries']");
 
-  async clickPropertiesButton() {
-    await this.propertiesButton().click();
-    return this;
-  }
+    async clickPropertiesButton() {
+        await this.propertiesButton().click();
+        return this;
+    }
 
-  async clickAddButton() {
-    await this.addButton().click();
-    return this;
-  }
+    async clickAddButton() {
+        await this.addButton().click();
+        return this;
+    }
 
-  async fillLibraryName(libraryName: string) {
-    await this.libraryInputField().fill(libraryName);
-    return this;
-  }
+    async fillLibraryName(libraryName: string) {
+        await this.libraryInputField().fill(libraryName);
+        return this;
+    }
 
-  async fillDisplayName(displayName: string) {
-    await this.displayNameInput().fill(displayName);
-    return this;
-  }
+    async fillDisplayName(displayName: string) {
+        await this.displayNameInput().fill(displayName);
+        return this;
+    }
 
-  async fillDescription(description: string) {
-    await this.descriptionInput().fill(description);
-    return this;
-  }
+    async fillDescription(description: string) {
+        await this.descriptionInput().fill(description);
+        return this;
+    }
 
-  async clickApplyButton() {
-    await this.applyButton().click();
-    return this;
-  }
-  async clickSaveButton() {
-    await this.submitButton().click();
-  }
+    async clickApplyButton() {
+        await this.applyButton().click();
+        return this;
+    }
+
+    async clickSaveButton() {
+        await this.submitButton().click();
+    }
+
+    async clickPipelineLibrariesButton() {
+        await this.pipelineLibrariesButton().click();
+        return this;
+    }
 }

--- a/POM/pageObjects/pages/StatusFolderPage.ts
+++ b/POM/pageObjects/pages/StatusFolderPage.ts
@@ -1,0 +1,10 @@
+import { BasePage } from "./@components";
+
+export class StatusFolderPage extends BasePage {
+    configureLink = () => this.page.locator('a[href*="/configure"]');
+
+    async clickConfigureLink() {
+        await this.configureLink().click();
+        return this;
+    }
+}

--- a/POM/testData/configureFolderPageData.ts
+++ b/POM/testData/configureFolderPageData.ts
@@ -1,8 +1,7 @@
 import { faker } from "@faker-js/faker";
 
 export const configureFolderPageData = {
-  libraryName: faker.word.noun(),
-  displayName: `Display-${faker.string.alphanumeric(6)}`,
-  description: faker.lorem.sentence(),
-  folderName: `folder-${faker.string.alphanumeric(8)}`,
+    libraryName: faker.word.noun(),
+    displayName: `Display-${faker.string.alphanumeric(6)}`,
+    description: faker.lorem.sentence(),
 };

--- a/POM/tests/ConfigureFolderPage.spec.ts
+++ b/POM/tests/ConfigureFolderPage.spec.ts
@@ -2,43 +2,32 @@ import { test, expect, App } from "@/POM/fixtures/baseFixtures";
 import { newItemPageData } from "../testData/newItemPageData";
 import { configureFolderPageData } from "../testData/configureFolderPageData";
 
-test.describe("US_05.001 | Folder Configuration > Display Name and Description", () => {
-    test("RF_05.001.03 | Verify Configure page opens", async ({
-        app,
-    }: {
-        app: App;
-    }) => {
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.createFolder(newItemPageData.folderName);
+test.describe("US_05 | Folder Configuration", () => {
+    let folderName: string;
 
+    test.beforeEach(async ({ app }: { app: App }) => {
+        folderName = newItemPageData.folderName;
+
+        await app.homePage.clickNewItemLink();
+        await app.newItemPage.createFolder(folderName);
+    });
+
+    test("RF_05.001.03 | Verify Configure page opens", async ({ app }) => {
         await expect(app.configureFolderPage.generalSection()).toBeVisible();
     });
 
     test("RF_05.001.04 | Verify Display Name and Description fields are available", async ({
         app,
-    }: {
-        app: App;
     }) => {
-        const folderName = configureFolderPageData.folderName;
-
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.createFolder(folderName);
-
         await expect(app.configureFolderPage.displayNameInput()).toBeVisible();
         await expect(app.configureFolderPage.descriptionInput()).toBeVisible();
     });
 
     test("RF_05.001.08 | Verify Apply saves changes without leaving page", async ({
         app,
-    }: {
-        app: App;
     }) => {
-        const folderName = configureFolderPageData.folderName;
         const displayName = configureFolderPageData.displayName;
         const description = configureFolderPageData.description;
-
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.createFolder(folderName);
 
         await expect(app.configureFolderPage.generalSection()).toBeVisible();
         await app.configureFolderPage.fillDisplayName(displayName);
@@ -50,42 +39,20 @@ test.describe("US_05.001 | Folder Configuration > Display Name and Description",
         await expect(app.configureFolderPage.displayNameInput()).toHaveValue(
             displayName,
         );
+
         await expect(app.configureFolderPage.descriptionInput()).toHaveValue(
             description,
         );
     });
-});
 
-test.describe("US_05.003 | Folder Configuration > Pipeline Libraries", (): void => {
-    test("RF_05.003.01 | Verify adding Pipeline library", async ({
-        app,
-    }: {
-        app: App;
-    }) => {
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.fillItemNameField(newItemPageData.itemName);
-        await app.newItemPage.clickFolderAndOkButton();
-
-        await app.configureFolderPage.header.clickHome();
-
-        await app.homePage.hoverItemName();
-        await app.homePage.openItemDropdownMenu();
-        await app.homePage.clickItemDropDownConfigureButton(
-            newItemPageData.itemName,
-        );
-
+    test("RF_05.003.01 | Verify adding Pipeline library", async ({ app }) => {
         await app.configureFolderPage.clickPropertiesButton();
         await app.configureFolderPage.clickAddButton();
         await app.configureFolderPage.fillLibraryName(
             configureFolderPageData.libraryName,
         );
-        //Иногда Save не срабатывает, поэтому передаю itemName, чтобы точно перерйти на страницу после клика по Save
         await app.configureFolderPage.clickSaveButton();
-
-        await app.homePage.clickItemDropDownConfigureButton(
-            newItemPageData.itemName,
-        );
-        await app.configureFolderPage.clickPropertiesButton();
+        await app.statusFolderPage.clickConfigureLink();
 
         await expect(app.configureFolderPage.libraryInputField()).toHaveValue(
             configureFolderPageData.libraryName,


### PR DESCRIPTION
## Summary

Refactored ConfigureFolderPage spec structure and stabilized Folder Configuration tests.

## Changes

- Consolidated ConfigureFolderPage.spec.ts under one main describe
- Moved common folder creation setup to beforeEach
- Added StatusFolderPage for Folder status navigation
- Stabilized Pipeline Library test by replacing Home dropdown navigation with Status Folder Configure link
- Reused existing ConfigureFolderPage POM methods
- Preserved existing Folder Configuration coverage

## Validation

- ConfigureFolderPage.spec.ts passed locally
- Related tests passed locally

https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=190238824&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C671