### PR TITLE
RF_09 | Refactor BuildHistoryPage spec structure

### DIFF
--- a/POM/pageObjects/pages/BuildHistoryPage.ts
+++ b/POM/pageObjects/pages/BuildHistoryPage.ts
@@ -1,15 +1,11 @@
 import { BasePage } from "./@components";
 
 export class BuildHistoryPage extends BasePage {
-    successfulBuildEntry = (projectName: string) =>
-        this.page.locator("tr", { hasText: projectName });
-    newItemName = () =>
-        this.page.locator("#projectStatus .jenkins-table__link span");
-    successfulBuildStatusIcon = (projectName: string) =>
-        this.successfulBuildEntry(projectName).locator("svg#blue");
+    successfulBuildEntry = (projectName: string) => this.page.locator("tr", { hasText: projectName });
+    newItemName = () => this.page.locator("#projectStatus .jenkins-table__link span");
+    successfulBuildStatusIcon = (projectName: string) => this.successfulBuildEntry(projectName).locator("svg#blue");
     buildValues = () => this.page.getByText(/^#\d+$/);
-    sortableBuildHeader = () =>
-        this.page.locator("th[initialsortdir='up'] a.sortheader");
+    sortableBuildHeader = () => this.page.locator("th[initialsortdir='up'] a.sortheader");
     firstBuildNumberLink = () => this.buildValues().first();
 
     async clickSortableBuildHeader() {

--- a/POM/tests/BuildHistoryPage.spec.ts
+++ b/POM/tests/BuildHistoryPage.spec.ts
@@ -1,115 +1,67 @@
 import { test, expect, App } from "@/POM/fixtures/baseFixtures";
 import { newItemPageData } from "@/POM/testData/newItemPageData";
 
-test.describe("US_09.001 | Build history > Core Build History Display", () => {
-    test("RF_09.001.01 | Item displays on Build History page after building", async ({
-        app,
-    }) => {
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.fillItemNameField(newItemPageData.itemName);
-        await app.newItemPage.clickFreestyleProject();
-        await app.newItemPage.clickOkButton();
+test.describe("US_09 | Build history", () => {
+    let projectName: string;
 
-        await app.configureFreestylePage.saveChanges();
-        await app.statusFreestyleProjectPage.clickBuildNowLink();
-        await app.statusFreestyleProjectPage.header.clickHome();
-        await app.homePage.clickBuildHistoryLink();
-
-        await expect(app.buildHistoryPage.newItemName()).toContainText(
-            newItemPageData.itemName,
-        );
-    });
-
-    test("RF_09.001.03 | Verify Build History displays list of builds", async ({
-        app,
-    }: {
-        app: App;
-    }) => {
-        const projectName = newItemPageData.itemName;
-        const expectedBuildNumbers = ["#3", "#2", "#1"];
+    test.beforeEach(async ({ app }) => {
+        projectName = newItemPageData.itemName;
 
         await app.homePage.clickNewItemLink();
         await app.newItemPage.createFreestyleProject(projectName);
         await app.configureFreestylePage.clickSaveButton();
-
-        await app.statusFreestyleProjectPage.createBuilds(
-            expectedBuildNumbers.length,
-        );
-
-        await app.statusFreestyleProjectPage.header.clickHome();
-        await app.homePage.clickBuildHistoryLink();
-
-        await expect(app.buildHistoryPage.buildValues()).toHaveCount(
-            expectedBuildNumbers.length,
-        );
-
-        await expect(app.buildHistoryPage.buildValues()).toHaveText(
-            expectedBuildNumbers,
-        );
     });
 
-    test("RF_09.001.05 | Verify successful build entry displays success status icon", async ({
-        app,
-    }) => {
-        const projectName = newItemPageData.itemName;
-
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.createFreestyleProject(projectName);
-        await app.configureFreestylePage.clickSaveButton();
-
-        await app.statusFreestyleProjectPage.clickBuildNowLink();
-        await app.statusFreestyleProjectPage.buildNumber("#1").waitFor();
+    async function openBuildHistory(app: App) {
         await app.header.clickHome();
         await app.homePage.clickBuildHistoryLink();
+    }
 
-        await expect(
-            app.buildHistoryPage.successfulBuildStatusIcon(projectName),
-        ).toBeVisible();
+    test("RF_09.001.01 | Item displays on Build History page after building", async ({ app }) => {
+        await app.statusFreestyleProjectPage.clickBuildNowLink();
+        await openBuildHistory(app);
+
+        await expect(app.buildHistoryPage.newItemName()).toContainText(newItemPageData.itemName);
     });
 
-    test("RF_09.001.06 | Verify build number links to Build Summary page", async ({
-        app,
-    }: {
-        app: App;
-    }) => {
-        const projectName = newItemPageData.itemName;
+    test("RF_09.001.03 | Verify Build History displays list of builds", async ({ app }) => {
+        const expectedBuildNumbers = ["#3", "#2", "#1"];
 
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.createFreestyleProject(projectName);
+        await app.statusFreestyleProjectPage.createBuilds(expectedBuildNumbers.length);
 
-        await app.configureFreestylePage.clickSaveButton();
+        await openBuildHistory(app);
+
+        await expect(app.buildHistoryPage.buildValues()).toHaveCount(expectedBuildNumbers.length);
+
+        await expect(app.buildHistoryPage.buildValues()).toHaveText(expectedBuildNumbers);
+    });
+
+    test("RF_09.001.05 | Verify successful build entry displays success status icon", async ({ app }) => {
+        await app.statusFreestyleProjectPage.clickBuildNowLink();
+        await app.statusFreestyleProjectPage.buildNumber("#1").waitFor();
+
+        await openBuildHistory(app);
+
+        await expect(app.buildHistoryPage.successfulBuildStatusIcon(projectName)).toBeVisible();
+    });
+
+    test("RF_09.001.06 | Verify build number links to Build Summary page", async ({ app }) => {
         await app.statusFreestyleProjectPage.createBuilds(1);
 
-        await app.statusFreestyleProjectPage.header.clickHome();
-        await app.homePage.clickBuildHistoryLink();
+        await openBuildHistory(app);
 
         await expect(app.buildHistoryPage.firstBuildNumberLink()).toBeVisible();
 
         const buildNumber = await app.buildHistoryPage.getFirstBuildNumber();
         const buildId = buildNumber?.replace("#", "");
 
-        await expect(
-            app.buildHistoryPage.firstBuildNumberLink(),
-        ).toHaveAttribute("href", new RegExp(`${buildId}/?$`));
+        await expect(app.buildHistoryPage.firstBuildNumberLink()).toHaveAttribute("href", new RegExp(`${buildId}/?$`));
     });
-});
 
-test.describe("US_09.002 | Build history > Sorting", () => {
-    test("RF_09.002.02 | Verify sorting toggle changes build order", async ({
-        app,
-    }: {
-        app: App;
-    }) => {
-        const projectName = newItemPageData.itemName;
-
-        await app.homePage.clickNewItemLink();
-        await app.newItemPage.createFreestyleProject(projectName);
-
-        await app.configureFreestylePage.clickSaveButton();
+    test("RF_09.002.02 | Verify sorting toggle changes build order", async ({ app }) => {
         await app.statusFreestyleProjectPage.createBuilds(4);
 
-        await app.statusFreestyleProjectPage.header.clickHome();
-        await app.homePage.clickBuildHistoryLink();
+        await openBuildHistory(app);
 
         await expect(app.buildHistoryPage.buildValues().first()).toBeVisible();
 


### PR DESCRIPTION
Summary:
Refactored BuildHistoryPage.spec.ts structure and reduced duplicated setup.

Changes:
- Added beforeEach for common project creation setup
- Removed duplicated New Item creation steps from tests
- Added openBuildHistory helper for repeated navigation
- Simplified Build History tests structure
- Reused shared projectName variable
- Cleaned unused code and comments

Validation:
- BuildHistoryPage.spec.ts passed locally
- Related tests passed locally

https://github.com/orgs/RedRoverSchool/projects/16/views/2?pane=issue&itemId=190658857&issue=RedRoverSchool%7CJenkinsQA_JS_2026_spring%7C690